### PR TITLE
fix AudioStreamPlayer3D volume_db affecting only attenuation distance…

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1739,6 +1739,10 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_RST("audio/general/text_to_speech", false);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/general/2d_panning_strength", PROPERTY_HINT_RANGE, "0,2,0.01"), 0.5f);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/general/3d_panning_strength", PROPERTY_HINT_RANGE, "0,2,0.01"), 0.5f);
+	// True by default in order to keep compatibility with 4.5 and lower.
+	// Set to false when creating a new project.
+	// This probably should be false by default for 5.x
+	GLOBAL_DEF_RST(PropertyInfo(Variant::BOOL, "audio/general/3d_volume_db_affects_attenuation"), true);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/ios/session_category", PROPERTY_HINT_ENUM, "Ambient,Multi Route,Play and Record,Playback,Record,Solo Ambient"), 0);
 	GLOBAL_DEF("audio/general/ios/mix_with_others", false);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -469,6 +469,10 @@
 			The base strength of the panning effect for all [AudioStreamPlayer3D] nodes. The panning strength can be further scaled on each Node using [member AudioStreamPlayer3D.panning_strength]. A value of [code]0.0[/code] disables stereo panning entirely, leaving only volume attenuation in place. A value of [code]1.0[/code] completely mutes one of the channels if the sound is located exactly to the left (or right) of the listener.
 			The default value of [code]0.5[/code] is tuned for headphones which means that the opposite side channel goes no lower than 50% of the volume of the nearside channel. You may find that you can set this value higher for speakers to have the same effect since both ears can hear from each speaker.
 		</member>
+		<member name="audio/general/3d_volume_db_affects_attenuation" type="bool" setter="" getter="" default="true">
+			When set to [code]true[/code], the [AudioStreamPlayer3D] property [member AudioStreamPlayer3D.volume_db] will offset attenuation instead of directly offsetting the volume of the sound.
+			This defaults to [code]false[/code] for projects created starting in Godot 4.6.
+		</member>
 		<member name="audio/general/default_playback_type" type="int" setter="" getter="" default="0" experimental="" keywords="stream, sample">
 			Specifies the default playback type of the platform.
 			The default value is set to [b]Stream[/b], as most platforms have no issues mixing streams.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7902,6 +7902,7 @@ HashMap<String, Variant> EditorNode::get_initial_settings() {
 	HashMap<String, Variant> settings;
 	settings["physics/3d/physics_engine"] = "Jolt Physics";
 	settings["rendering/rendering_device/driver.windows"] = "d3d12";
+	settings["audio/general/3d_volume_db_affects_attenuation"] = false;
 	return settings;
 }
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -251,7 +251,10 @@ float AudioStreamPlayer3D::_get_attenuation_db(float p_distance) const {
 		}
 	}
 
-	att += internal->volume_db;
+	if (AudioServer::get_singleton()->cached_volume_db_affects_3d_attenuation) {
+		att += internal->volume_db;
+	}
+
 	if (att > max_db) {
 		att = max_db;
 	}
@@ -472,6 +475,10 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 			float tightness = cached_global_panning_strength * 2.0f;
 			tightness *= panning_strength;
 			_calc_output_vol(local_pos.normalized(), tightness, output_volume_vector);
+		}
+
+		if (!AudioServer::get_singleton()->cached_volume_db_affects_3d_attenuation) {
+			multiplier *= Math::db_to_linear(internal->volume_db);
 		}
 
 		for (unsigned int k = 0; k < 4; k++) {

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -2049,6 +2049,7 @@ void AudioServer::_bind_methods() {
 
 AudioServer::AudioServer() {
 	singleton = this;
+	cached_volume_db_affects_3d_attenuation = GLOBAL_GET_CACHED(bool, "audio/general/3d_volume_db_affects_attenuation");
 }
 
 AudioServer::~AudioServer() {

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -206,6 +206,7 @@ public:
 	};
 
 	typedef void (*AudioCallback)(void *p_userdata);
+	bool cached_volume_db_affects_3d_attenuation = true;
 
 private:
 	uint64_t mix_time = 0;


### PR DESCRIPTION
… calculation, not actual volume.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
